### PR TITLE
[debugger] Add basic UI structure and partially implement model type selector

### DIFF
--- a/.github/workflows/deploy-debugger-prod.yml
+++ b/.github/workflows/deploy-debugger-prod.yml
@@ -3,7 +3,7 @@ name: Deploy TFJS Debugger Site to Live
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - 'toolings/tfjs-debugger/**'
 

--- a/toolings/tfjs-debugger/.stylelintrc.json
+++ b/toolings/tfjs-debugger/.stylelintrc.json
@@ -12,6 +12,9 @@
   ],
   "ignoreFiles": ["src/theme.scss", "node_modules/**/*.*"],
   "rules": {
-    "string-quotes": "single"
+    "string-quotes": "single",
+    "selector-pseudo-element-no-unknown": [true, {
+      "ignorePseudoElements": ["ng-deep"]
+    }]
   }
 }

--- a/toolings/tfjs-debugger/package.json
+++ b/toolings/tfjs-debugger/package.json
@@ -56,5 +56,13 @@
     "test-ci": "ng test --karma-config karma-ci.conf.js",
     "deploy-firebase": "./scripts/deploy-to-firebase.sh",
     "deploy-firebase-dev": "./scripts/deploy-to-firebase.sh --dev"
+  },
+  "resolutions": {
+    "set-value": "^4.0.1",
+    "trim-newlines": "^3.0.1",
+    "glob-parent": "^5.1.2",
+    "trim": "^0.0.3",
+    "yargs-parser": "^13.1.2",
+    "ansi-regex": "^5.0.1"
   }
 }

--- a/toolings/tfjs-debugger/src/app/app/app.component.html
+++ b/toolings/tfjs-debugger/src/app/app/app.component.html
@@ -15,5 +15,18 @@ limitations under the License.
 -->
 
 <div class="container">
-  This is {{title}}
+  <!-- The app bar at the top -->
+  <app-bar></app-bar>
+
+  <!-- Content under app bar -->
+  <div class="content">
+    <!-- The config panel at the left -->
+    <configs-panel></configs-panel>
+
+    <!-- The model graph panel at the center -->
+    <graph-panel></graph-panel>
+
+    <!-- The info graph panel at the right -->
+    <info-panel></info-panel>
+  </div>
 </div>

--- a/toolings/tfjs-debugger/src/app/app/app.component.scss
+++ b/toolings/tfjs-debugger/src/app/app/app.component.scss
@@ -17,7 +17,13 @@
 
 .container {
   display: flex;
-  align-items: center;
-  justify-content: center;
+  flex-direction: column;
   height: 100%;
+  overflow: hidden;
+
+  .content {
+    display: flex;
+    flex-grow: 1;
+    overflow: hidden;
+  }
 }

--- a/toolings/tfjs-debugger/src/app/app/app.module.ts
+++ b/toolings/tfjs-debugger/src/app/app/app.module.ts
@@ -17,11 +17,16 @@
 
 import {NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {RouterModule} from '@angular/router';
 import {routerReducer, StoreRouterConnectingModule} from '@ngrx/router-store';
 import {StoreModule} from '@ngrx/store';
 import {StoreDevtoolsModule} from '@ngrx/store-devtools';
 
+import {AppBarModule} from '../components/app_bar/app_bar.module';
+import {ConfigsPanelModule} from '../components/configs_panel/configs_panel.module';
+import {GraphPaneModule} from '../components/graph_panel/graph_panel.module';
+import {InfoPanelModule} from '../components/info_panel/info_panel.module';
 import {configsReducer} from '../store/reducers';
 
 import {AppComponent} from './app.component';
@@ -30,7 +35,12 @@ import {AppComponent} from './app.component';
 @NgModule({
   declarations: [AppComponent],
   imports: [
+    AppBarModule,
     BrowserModule,
+    BrowserAnimationsModule,
+    ConfigsPanelModule,
+    InfoPanelModule,
+    GraphPaneModule,
     StoreModule.forRoot({
       router: routerReducer,
       configs: configsReducer,

--- a/toolings/tfjs-debugger/src/app/common/types.ts
+++ b/toolings/tfjs-debugger/src/app/common/types.ts
@@ -1,6 +1,24 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 /** URL parameter keys. */
 export enum UrlParamKey {
-  SELECTED_MODEL_TYPE_ID = 'm',
+  SELECTED_MODEL_TYPE_ID = 'mid',
+  TFJS_MODEL_URL = 'tfjsmu',
 }
 
 /** Valid config index. */

--- a/toolings/tfjs-debugger/src/app/common/types.ts
+++ b/toolings/tfjs-debugger/src/app/common/types.ts
@@ -1,0 +1,7 @@
+/** URL parameter keys. */
+export enum UrlParamKey {
+  SELECTED_MODEL_TYPE_ID = 'm',
+}
+
+/** Valid config index. */
+export type ConfigIndex = 0|1;

--- a/toolings/tfjs-debugger/src/app/common/utils.ts
+++ b/toolings/tfjs-debugger/src/app/common/utils.ts
@@ -1,7 +1,28 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 import {UrlParamKey} from './types';
 
 const CONFIG_INDEX_SEP = '__';
 
+/**
+ * A helper function to append config index (0 or 1) to the given url parameter
+ * key.
+ */
 export function appendConfigIndexToKey(paramKey: UrlParamKey, index: number) {
   return `${paramKey}${CONFIG_INDEX_SEP}${index}`;
 }

--- a/toolings/tfjs-debugger/src/app/common/utils.ts
+++ b/toolings/tfjs-debugger/src/app/common/utils.ts
@@ -1,0 +1,7 @@
+import {UrlParamKey} from './types';
+
+const CONFIG_INDEX_SEP = '__';
+
+export function appendConfigIndexToKey(paramKey: UrlParamKey, index: number) {
+  return `${paramKey}${CONFIG_INDEX_SEP}${index}`;
+}

--- a/toolings/tfjs-debugger/src/app/components/app_bar/app_bar.component.html
+++ b/toolings/tfjs-debugger/src/app/components/app_bar/app_bar.component.html
@@ -1,3 +1,19 @@
+<!-- Copyright 2021 Google LLC. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================
+-->
+
 <div class="container">
   <!-- App icon and title -->
   <div class="app-title-container">

--- a/toolings/tfjs-debugger/src/app/components/app_bar/app_bar.component.html
+++ b/toolings/tfjs-debugger/src/app/components/app_bar/app_bar.component.html
@@ -1,0 +1,12 @@
+<div class="container">
+  <!-- App icon and title -->
+  <div class="app-title-container">
+    <img class="icon" src="../../../favicon.svg">
+    <div class="title">TFJS Debugger</div>
+  </div>
+
+  <!-- Action buttons -->
+  <div class="btns-container">
+    <button mat-flat-button color="primary">Run</button>
+  </div>
+</div>

--- a/toolings/tfjs-debugger/src/app/components/app_bar/app_bar.component.scss
+++ b/toolings/tfjs-debugger/src/app/components/app_bar/app_bar.component.scss
@@ -1,0 +1,29 @@
+@use '../../../variables' as var;
+
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 64px;
+  padding: 0 var.$spacing-3x;
+  overflow: hidden;
+  border-bottom: 1px solid var.$grey-200;
+
+  .app-title-container {
+    display: flex;
+    align-items: center;
+    height: 100%;
+
+    .icon {
+      width: 24px;
+      margin-right: var.$spacing-3x;
+    }
+
+    .title {
+      color: var.$grey-800;
+      font-weight: 700;
+      font-size: var.$font-size-large;
+      text-transform: uppercase;
+    }
+  }
+}

--- a/toolings/tfjs-debugger/src/app/components/app_bar/app_bar.component.scss
+++ b/toolings/tfjs-debugger/src/app/components/app_bar/app_bar.component.scss
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 @use '../../../variables' as var;
 
 .container {

--- a/toolings/tfjs-debugger/src/app/components/app_bar/app_bar.component.ts
+++ b/toolings/tfjs-debugger/src/app/components/app_bar/app_bar.component.ts
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 import {ChangeDetectionStrategy, Component, OnInit} from '@angular/core';
 
 /**

--- a/toolings/tfjs-debugger/src/app/components/app_bar/app_bar.component.ts
+++ b/toolings/tfjs-debugger/src/app/components/app_bar/app_bar.component.ts
@@ -1,0 +1,17 @@
+import {ChangeDetectionStrategy, Component, OnInit} from '@angular/core';
+
+/**
+ * The app bar located at the top of the screen that shows the app title and a
+ * set of action buttons.
+ */
+@Component({
+  selector: 'app-bar',
+  templateUrl: './app_bar.component.html',
+  styleUrls: ['./app_bar.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AppBar implements OnInit {
+  constructor() {}
+
+  ngOnInit() {}
+}

--- a/toolings/tfjs-debugger/src/app/components/app_bar/app_bar.module.ts
+++ b/toolings/tfjs-debugger/src/app/components/app_bar/app_bar.module.ts
@@ -1,0 +1,20 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {MatButtonModule} from '@angular/material/button';
+
+import {AppBar} from './app_bar.component';
+
+@NgModule({
+  declarations: [
+    AppBar,
+  ],
+  imports: [
+    CommonModule,
+    MatButtonModule,
+  ],
+  exports: [
+    AppBar,
+  ],
+})
+export class AppBarModule {
+}

--- a/toolings/tfjs-debugger/src/app/components/app_bar/app_bar.module.ts
+++ b/toolings/tfjs-debugger/src/app/components/app_bar/app_bar.module.ts
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {MatButtonModule} from '@angular/material/button';

--- a/toolings/tfjs-debugger/src/app/components/config_section/config_section.component.html
+++ b/toolings/tfjs-debugger/src/app/components/config_section/config_section.component.html
@@ -1,3 +1,19 @@
+<!-- Copyright 2021 Google LLC. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================
+-->
+
 <div class="container">
   <!-- Model selector -->
   <div class="section">

--- a/toolings/tfjs-debugger/src/app/components/config_section/config_section.component.html
+++ b/toolings/tfjs-debugger/src/app/components/config_section/config_section.component.html
@@ -1,0 +1,7 @@
+<div class="container">
+  <!-- Model selector -->
+  <div class="section">
+    <div class="title">Model</div>
+    <model-selector [configIndex]="configIndex"></model-selector>
+  </div>
+</div>

--- a/toolings/tfjs-debugger/src/app/components/config_section/config_section.component.scss
+++ b/toolings/tfjs-debugger/src/app/components/config_section/config_section.component.scss
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 @use '../../../variables' as var;
 
 .container {

--- a/toolings/tfjs-debugger/src/app/components/config_section/config_section.component.scss
+++ b/toolings/tfjs-debugger/src/app/components/config_section/config_section.component.scss
@@ -1,0 +1,13 @@
+@use '../../../variables' as var;
+
+.container {
+  box-sizing: border-box;
+  min-height: calc(50% - var.$config-header-height);
+  padding: var.$spacing-3x var.$spacing-3x;
+
+  .section {
+    .title {
+      font-weight: 500;
+    }
+  }
+}

--- a/toolings/tfjs-debugger/src/app/components/config_section/config_section.component.ts
+++ b/toolings/tfjs-debugger/src/app/components/config_section/config_section.component.ts
@@ -1,0 +1,21 @@
+import {ChangeDetectionStrategy, Component, Input, OnInit} from '@angular/core';
+import {ConfigIndex} from 'src/app/common/types';
+
+/** A single configuration in the configs panel. */
+@Component({
+  selector: 'config-section',
+  templateUrl: './config_section.component.html',
+  styleUrls: ['./config_section.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ConfigSection implements OnInit {
+  @Input() configIndex!: ConfigIndex;
+
+  constructor() {}
+
+  ngOnInit() {
+    if (this.configIndex == null) {
+      throw new Error('configIndex not set');
+    }
+  }
+}

--- a/toolings/tfjs-debugger/src/app/components/config_section/config_section.component.ts
+++ b/toolings/tfjs-debugger/src/app/components/config_section/config_section.component.ts
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 import {ChangeDetectionStrategy, Component, Input, OnInit} from '@angular/core';
 import {ConfigIndex} from 'src/app/common/types';
 

--- a/toolings/tfjs-debugger/src/app/components/config_section/config_section.module.ts
+++ b/toolings/tfjs-debugger/src/app/components/config_section/config_section.module.ts
@@ -1,0 +1,21 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+
+import {ModelSelectorModule} from '../model_selector/model_selector.module';
+
+import {ConfigSection} from './config_section.component';
+
+@NgModule({
+  declarations: [
+    ConfigSection,
+  ],
+  imports: [
+    CommonModule,
+    ModelSelectorModule,
+  ],
+  exports: [
+    ConfigSection,
+  ]
+})
+export class ConfigSectionModule {
+}

--- a/toolings/tfjs-debugger/src/app/components/config_section/config_section.module.ts
+++ b/toolings/tfjs-debugger/src/app/components/config_section/config_section.module.ts
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 

--- a/toolings/tfjs-debugger/src/app/components/configs_panel/configs_panel.component.html
+++ b/toolings/tfjs-debugger/src/app/components/configs_panel/configs_panel.component.html
@@ -1,0 +1,18 @@
+<div class="container">
+  <!--
+    Configuration 1.
+
+    Leave the header outside config-section for better supporting sticky
+    header when scrolling.
+  -->
+  <div class="config-header">
+    Configuration 1
+  </div>
+  <config-section [configIndex]="0"></config-section>
+
+  <!-- Configuration 2 -->
+  <div class="config-header">
+    Configuration 2
+  </div>
+  <config-section [configIndex]="1"></config-section>
+</div>

--- a/toolings/tfjs-debugger/src/app/components/configs_panel/configs_panel.component.html
+++ b/toolings/tfjs-debugger/src/app/components/configs_panel/configs_panel.component.html
@@ -1,3 +1,19 @@
+<!-- Copyright 2021 Google LLC. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================
+-->
+
 <div class="container">
   <!--
     Configuration 1.

--- a/toolings/tfjs-debugger/src/app/components/configs_panel/configs_panel.component.scss
+++ b/toolings/tfjs-debugger/src/app/components/configs_panel/configs_panel.component.scss
@@ -1,0 +1,23 @@
+@use '../../../variables' as var;
+
+.container {
+  width: 300px;
+  height: 100%;
+  overflow-y: auto;
+  font-size: var.$font-size-small;
+  background-color: #f3f6fb;
+  border-right: 1px solid var.$grey-200;
+
+  .config-header {
+    position: sticky;
+    top: 0;
+    display: flex;
+    align-items: center;
+    height: var.$config-header-height;
+    padding: 0 var.$spacing-3x;
+    color: var.$grey-800;
+    font-weight: 500;
+    font-size: var.$font-size-normal;
+    background-color: #e7edf7;
+  }
+}

--- a/toolings/tfjs-debugger/src/app/components/configs_panel/configs_panel.component.scss
+++ b/toolings/tfjs-debugger/src/app/components/configs_panel/configs_panel.component.scss
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 @use '../../../variables' as var;
 
 .container {

--- a/toolings/tfjs-debugger/src/app/components/configs_panel/configs_panel.component.ts
+++ b/toolings/tfjs-debugger/src/app/components/configs_panel/configs_panel.component.ts
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 import {ChangeDetectionStrategy, Component, OnInit} from '@angular/core';
 
 /**

--- a/toolings/tfjs-debugger/src/app/components/configs_panel/configs_panel.component.ts
+++ b/toolings/tfjs-debugger/src/app/components/configs_panel/configs_panel.component.ts
@@ -1,0 +1,20 @@
+import {ChangeDetectionStrategy, Component, OnInit} from '@angular/core';
+
+/**
+ * The configs panel located at the left of the screen where users set up 2
+ * configurations for comparison (or 1 configuration for single-configuration
+ * mode).
+ *
+ * Each configuration section is implemented in the `config-section` component.
+ */
+@Component({
+  selector: 'configs-panel',
+  templateUrl: './configs_panel.component.html',
+  styleUrls: ['./configs_panel.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ConfigsPanel implements OnInit {
+  constructor() {}
+
+  ngOnInit() {}
+}

--- a/toolings/tfjs-debugger/src/app/components/configs_panel/configs_panel.module.ts
+++ b/toolings/tfjs-debugger/src/app/components/configs_panel/configs_panel.module.ts
@@ -1,0 +1,21 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+
+import {ConfigSectionModule} from '../config_section/config_section.module';
+
+import {ConfigsPanel} from './configs_panel.component';
+
+@NgModule({
+  declarations: [
+    ConfigsPanel,
+  ],
+  imports: [
+    CommonModule,
+    ConfigSectionModule,
+  ],
+  exports: [
+    ConfigsPanel,
+  ]
+})
+export class ConfigsPanelModule {
+}

--- a/toolings/tfjs-debugger/src/app/components/configs_panel/configs_panel.module.ts
+++ b/toolings/tfjs-debugger/src/app/components/configs_panel/configs_panel.module.ts
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 

--- a/toolings/tfjs-debugger/src/app/components/graph_panel/graph_panel.component.html
+++ b/toolings/tfjs-debugger/src/app/components/graph_panel/graph_panel.component.html
@@ -1,0 +1,3 @@
+<div class="container">
+  Model graph
+</div>

--- a/toolings/tfjs-debugger/src/app/components/graph_panel/graph_panel.component.html
+++ b/toolings/tfjs-debugger/src/app/components/graph_panel/graph_panel.component.html
@@ -1,3 +1,19 @@
+<!-- Copyright 2021 Google LLC. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================
+-->
+
 <div class="container">
   Model graph
 </div>

--- a/toolings/tfjs-debugger/src/app/components/graph_panel/graph_panel.component.scss
+++ b/toolings/tfjs-debugger/src/app/components/graph_panel/graph_panel.component.scss
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 @use '../../../variables' as var;
 
 :host {

--- a/toolings/tfjs-debugger/src/app/components/graph_panel/graph_panel.component.scss
+++ b/toolings/tfjs-debugger/src/app/components/graph_panel/graph_panel.component.scss
@@ -1,0 +1,13 @@
+@use '../../../variables' as var;
+
+:host {
+  flex-grow: 1;
+}
+
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  overflow: hidden;
+}

--- a/toolings/tfjs-debugger/src/app/components/graph_panel/graph_panel.component.ts
+++ b/toolings/tfjs-debugger/src/app/components/graph_panel/graph_panel.component.ts
@@ -1,0 +1,13 @@
+import {ChangeDetectionStrategy, Component, OnInit} from '@angular/core';
+
+@Component({
+  selector: 'graph-panel',
+  templateUrl: './graph_panel.component.html',
+  styleUrls: ['./graph_panel.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class GraphPanel implements OnInit {
+  constructor() {}
+
+  ngOnInit() {}
+}

--- a/toolings/tfjs-debugger/src/app/components/graph_panel/graph_panel.component.ts
+++ b/toolings/tfjs-debugger/src/app/components/graph_panel/graph_panel.component.ts
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 import {ChangeDetectionStrategy, Component, OnInit} from '@angular/core';
 
 @Component({

--- a/toolings/tfjs-debugger/src/app/components/graph_panel/graph_panel.module.ts
+++ b/toolings/tfjs-debugger/src/app/components/graph_panel/graph_panel.module.ts
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 

--- a/toolings/tfjs-debugger/src/app/components/graph_panel/graph_panel.module.ts
+++ b/toolings/tfjs-debugger/src/app/components/graph_panel/graph_panel.module.ts
@@ -1,0 +1,18 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+
+import {GraphPanel} from './graph_panel.component';
+
+@NgModule({
+  declarations: [
+    GraphPanel,
+  ],
+  imports: [
+    CommonModule,
+  ],
+  exports: [
+    GraphPanel,
+  ],
+})
+export class GraphPaneModule {
+}

--- a/toolings/tfjs-debugger/src/app/components/info_panel/info_panel.component.html
+++ b/toolings/tfjs-debugger/src/app/components/info_panel/info_panel.component.html
@@ -1,3 +1,19 @@
+<!-- Copyright 2021 Google LLC. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================
+-->
+
 <div class="container">
   Info panel
 </div>

--- a/toolings/tfjs-debugger/src/app/components/info_panel/info_panel.component.html
+++ b/toolings/tfjs-debugger/src/app/components/info_panel/info_panel.component.html
@@ -1,0 +1,3 @@
+<div class="container">
+  Info panel
+</div>

--- a/toolings/tfjs-debugger/src/app/components/info_panel/info_panel.component.scss
+++ b/toolings/tfjs-debugger/src/app/components/info_panel/info_panel.component.scss
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 @use '../../../variables' as var;
 
 .container {

--- a/toolings/tfjs-debugger/src/app/components/info_panel/info_panel.component.scss
+++ b/toolings/tfjs-debugger/src/app/components/info_panel/info_panel.component.scss
@@ -1,0 +1,11 @@
+@use '../../../variables' as var;
+
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 300px;
+  height: 100%;
+  background-color: var.$grey-50;
+  border-left: 1px solid var.$grey-200;
+}

--- a/toolings/tfjs-debugger/src/app/components/info_panel/info_panel.component.ts
+++ b/toolings/tfjs-debugger/src/app/components/info_panel/info_panel.component.ts
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 import {ChangeDetectionStrategy, Component, OnInit} from '@angular/core';
 
 /**

--- a/toolings/tfjs-debugger/src/app/components/info_panel/info_panel.component.ts
+++ b/toolings/tfjs-debugger/src/app/components/info_panel/info_panel.component.ts
@@ -1,0 +1,17 @@
+import {ChangeDetectionStrategy, Component, OnInit} from '@angular/core';
+
+/**
+ * The info panel located at the right side of the screen. It shows the summary
+ * of the run and the detailed data for the selected node in the model graph.
+ */
+@Component({
+  selector: 'info-panel',
+  templateUrl: './info_panel.component.html',
+  styleUrls: ['./info_panel.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class InfoPanel implements OnInit {
+  constructor() {}
+
+  ngOnInit() {}
+}

--- a/toolings/tfjs-debugger/src/app/components/info_panel/info_panel.module.ts
+++ b/toolings/tfjs-debugger/src/app/components/info_panel/info_panel.module.ts
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 

--- a/toolings/tfjs-debugger/src/app/components/info_panel/info_panel.module.ts
+++ b/toolings/tfjs-debugger/src/app/components/info_panel/info_panel.module.ts
@@ -1,0 +1,18 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+
+import {InfoPanel} from './info_panel.component';
+
+@NgModule({
+  declarations: [
+    InfoPanel,
+  ],
+  imports: [
+    CommonModule,
+  ],
+  exports: [
+    InfoPanel,
+  ]
+})
+export class InfoPanelModule {
+}

--- a/toolings/tfjs-debugger/src/app/components/model_selector/model_selector.component.html
+++ b/toolings/tfjs-debugger/src/app/components/model_selector/model_selector.component.html
@@ -1,3 +1,19 @@
+<!-- Copyright 2021 Google LLC. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================
+-->
+
 <div class="container">
   <!-- Drop down select -->
   <mat-form-field appearance="outline" floatLabel="never">
@@ -19,8 +35,14 @@
 
     <!-- TFJS -->
     <div *ngSwitchCase="ModelTypeId.TFJS">
-      <mat-form-field appearance="outline" floatLabel="never">
-        <input #tfjsModelUrlInput matInput placeholder="URL for model.json">
+      <div class="title">Model url</div>
+      <mat-form-field appearance="outline">
+        <input #tfjsModelUrlInput
+               matInput
+               placeholder="URL for model.json"
+               class="tfjs-model-url-input"
+               [(ngModel)]="tfjsModelUrl"
+               (change)="handleTfjsModelUrlChanged()">
       </mat-form-field>
     </div>
 

--- a/toolings/tfjs-debugger/src/app/components/model_selector/model_selector.component.html
+++ b/toolings/tfjs-debugger/src/app/components/model_selector/model_selector.component.html
@@ -1,0 +1,29 @@
+<div class="container">
+  <!-- Drop down select -->
+  <mat-form-field appearance="outline" floatLabel="never">
+    <mat-select
+        [(value)]="selectedModelTypeId"
+        [class.same-as-config1-selected]="isSameAsConfig1Selected"
+        (selectionChange)="handleSelectionChange($event)">
+      <mat-option *ngFor="let option of modelTypes"
+          [value]="option.id"
+          [disabled]="option.disabled">
+        {{option.label}}
+      </mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <!-- Extra UI components for different model types -->
+  <div class="model-extra-components-container"
+       [ngSwitch]="selectedModelTypeId">
+
+    <!-- TFJS -->
+    <div *ngSwitchCase="ModelTypeId.TFJS">
+      <mat-form-field appearance="outline" floatLabel="never">
+        <input #tfjsModelUrlInput matInput placeholder="URL for model.json">
+      </mat-form-field>
+    </div>
+
+    <div *ngSwitchDefault></div>
+  </div>
+</div>

--- a/toolings/tfjs-debugger/src/app/components/model_selector/model_selector.component.scss
+++ b/toolings/tfjs-debugger/src/app/components/model_selector/model_selector.component.scss
@@ -1,6 +1,30 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 @use '../../../variables' as var;
 
 .container {
+  .title {
+    margin-top: var.$spacing-1x;
+    color: var.$grey-700;
+    font-size: var.$font-size-smaller;
+    line-height: 11px;
+  }
+
   mat-form-field {
     width: 100%;
   }

--- a/toolings/tfjs-debugger/src/app/components/model_selector/model_selector.component.scss
+++ b/toolings/tfjs-debugger/src/app/components/model_selector/model_selector.component.scss
@@ -1,0 +1,11 @@
+@use '../../../variables' as var;
+
+.container {
+  mat-form-field {
+    width: 100%;
+  }
+
+  mat-select.same-as-config1-selected ::ng-deep .mat-select-value-text {
+    font-style: italic;
+  }
+}

--- a/toolings/tfjs-debugger/src/app/components/model_selector/model_selector.component.spec.ts
+++ b/toolings/tfjs-debugger/src/app/components/model_selector/model_selector.component.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {HarnessLoader} from '@angular/cdk/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {MatInputHarness} from '@angular/material/input/testing';
+import {MatSelectHarness} from '@angular/material/select/testing';
+import {By} from '@angular/platform-browser';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {Router} from '@angular/router';
+import {RouterTestingModule} from '@angular/router/testing';
+import {routerReducer, RouterReducerState, SerializedRouterStateSnapshot, StoreRouterConnectingModule} from '@ngrx/router-store';
+import {createFeatureSelector, Store, StoreModule} from '@ngrx/store';
+import {UrlParamKey} from 'src/app/common/types';
+import {appendConfigIndexToKey} from 'src/app/common/utils';
+import {ModelTypeId} from 'src/app/data_model/model_type';
+import {AppState} from 'src/app/store/state';
+
+import {ModelSelector} from './model_selector.component';
+import {ModelSelectorModule} from './model_selector.module';
+
+describe('ModelSelector', () => {
+  let store: Store<AppState>;
+  let router: Router;
+  let fixture: ComponentFixture<ModelSelector>;
+  let loader: HarnessLoader;
+  const selectRouter = createFeatureSelector<RouterReducerState>('router');
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        ModelSelector,
+      ],
+      imports: [
+        ModelSelectorModule,
+        BrowserAnimationsModule,
+        RouterTestingModule,
+        StoreModule.forRoot({
+          'router': routerReducer,
+        }),
+        StoreRouterConnectingModule.forRoot(),
+      ],
+    });
+
+    router = TestBed.inject(Router);
+    store = TestBed.inject(Store);
+    fixture = TestBed.createComponent(ModelSelector);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should select the correct model type encoded in URL', fakeAsync(() => {
+       // Verify that the default selection is the first one in the modelTypes
+       // array.
+       fixture.componentInstance.configIndex = 1;
+       // Need 2 rounds of change detections (one for initial data binding and
+       // one for navigation) to properly update the UI
+       detectChanges(2);
+       const selectEle: HTMLElement =
+           fixture.debugElement.query(By.css('mat-select')).nativeElement;
+       expect(selectEle.textContent)
+           .toBe(fixture.componentInstance.modelTypes[0].label);
+
+       // After updating the url with modelTypeId = TFJS, verify that the
+       // model type selector has the correct one selected.
+       router.navigate([], {
+         queryParams: {
+           [appendConfigIndexToKey(
+               UrlParamKey.SELECTED_MODEL_TYPE_ID,
+               fixture.componentInstance.configIndex)]: `${ModelTypeId.TFJS}`,
+         }
+       });
+       detectChanges();
+
+       const tfjsModelType = fixture.componentInstance.modelTypes.find(
+           modelType => modelType.id === ModelTypeId.TFJS)!;
+       expect(selectEle.textContent).toBe(tfjsModelType.label);
+     }));
+
+  it('should set the correct content of the TFJS model url encoded in URL',
+     fakeAsync(() => {
+       fixture.componentInstance.configIndex = 0;
+       detectChanges(2);
+       // Update URL that encodes the tfjs model url to be "www.google.com".
+       const modelUrl = 'www.myweb.com/model.json';
+       router.navigate([], {
+         queryParams: {
+           [appendConfigIndexToKey(
+               UrlParamKey.TFJS_MODEL_URL,
+               fixture.componentInstance.configIndex)]: modelUrl,
+         }
+       });
+       detectChanges(2);
+
+       // Verify the input has the correct value.
+       const tfjsModelUrlInput: HTMLInputElement =
+           fixture.debugElement.query(By.css('.tfjs-model-url-input'))
+               .nativeElement;
+       expect(tfjsModelUrlInput.value).toBe(modelUrl);
+     }));
+
+  it('should show the correct UI components when TFJS model type is selected',
+     fakeAsync(() => {
+       // Verify that when TFJS model is selected (default), the TFJS model url
+       // input should appear.
+       fixture.componentInstance.configIndex = 0;
+       detectChanges(2);
+       expect(fixture.debugElement.query(By.css('.tfjs-model-url-input')))
+           .not.toBeNull();
+     }));
+
+  it('should correctly encode the selected model type in URL', fakeAsync(() => {
+       fixture.componentInstance.configIndex = 1;
+       detectChanges(2);
+
+       // Click the "TFJS model" in the model type selector.
+       const selectTFJSModelType = async () => {
+         const selector = await loader.getHarness(MatSelectHarness);
+         await selector.open();
+         const options = await selector.getOptions({text: 'TFJS model'});
+         await options[0].click();
+       };
+
+       selectTFJSModelType();
+       tick();
+
+       // Verify that the router store has the correct query param for the
+       // selected model type id.
+       let curRouterState!: RouterReducerState;
+       store.select(selectRouter).subscribe(routerState => {
+         curRouterState = routerState;
+       });
+       tick();
+
+       expect(curRouterState.state.root.queryParams[appendConfigIndexToKey(
+                  UrlParamKey.SELECTED_MODEL_TYPE_ID,
+                  fixture.componentInstance.configIndex)])
+           .toBe(`${ModelTypeId.TFJS}`);
+     }));
+
+  it('should correctly encode the TFJS model url string in URL',
+     fakeAsync(() => {
+       fixture.componentInstance.configIndex = 0;
+       detectChanges(2);
+
+       // Enter model url in the input element.
+       const modelUrl = 'www.myweb.com/model.json';
+       const enterTfjsModelUrl = async () => {
+         const input = await loader.getHarness(MatInputHarness);
+         await input.setValue(modelUrl);
+         await input.blur();
+       };
+
+       enterTfjsModelUrl();
+       tick();
+
+       // Need to manually fire the "change" event which will be handeled by the
+       // model selector.
+       const inputEle: HTMLInputElement =
+           fixture.debugElement.query(By.css('input')).nativeElement;
+       inputEle.dispatchEvent(new Event('change'));
+       tick();
+
+       // Verify that the router store has the correct query param for the
+       // selected model type id.
+       let curRouterState!: RouterReducerState;
+       store.select(selectRouter).subscribe(routerState => {
+         curRouterState = routerState;
+       });
+       tick();
+
+       expect(curRouterState.state.root.queryParams[appendConfigIndexToKey(
+                  UrlParamKey.TFJS_MODEL_URL,
+                  fixture.componentInstance.configIndex)])
+           .toBe(modelUrl);
+     }));
+
+  const detectChanges = (count = 1) => {
+    for (let i = 0; i < count; i++) {
+      tick();
+      fixture.detectChanges();
+    }
+  };
+});

--- a/toolings/tfjs-debugger/src/app/components/model_selector/model_selector.component.ts
+++ b/toolings/tfjs-debugger/src/app/components/model_selector/model_selector.component.ts
@@ -1,0 +1,138 @@
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Input, OnDestroy, OnInit, ViewChild} from '@angular/core';
+import {MatSelectChange} from '@angular/material/select';
+import {Store} from '@ngrx/store';
+import {takeWhile} from 'rxjs';
+import {ConfigIndex, UrlParamKey} from 'src/app/common/types';
+import {appendConfigIndexToKey} from 'src/app/common/utils';
+import {ModelTypeId} from 'src/app/data_model/model_type';
+import {UrlService} from 'src/app/services/url_service';
+import {selectConfigValueFromUrl} from 'src/app/store/selectors';
+import {AppState} from 'src/app/store/state';
+
+import {ModelTypeOption} from './types';
+
+
+/**
+ * A selector for users to select model type. After a model type is selected,
+ * the corresponding UI elements will be shown to gather more data from users
+ * for the selected model type.
+ *
+ * For example: when a user selects "TFJS model" from the selector, a text field
+ * will be shown for users to enter the model url.
+ */
+@Component({
+  selector: 'model-selector',
+  templateUrl: './model_selector.component.html',
+  styleUrls: ['./model_selector.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ModelSelector implements OnInit, OnDestroy {
+  @Input() configIndex: ConfigIndex = 0;
+
+  @ViewChild('tfjsModelUrlInput')
+  tfjsModelUrlInput!: ElementRef<HTMLInputElement>;
+
+  // Used by template.
+  ModelTypeId = ModelTypeId;
+
+  /** All supported model types.  */
+  readonly modelTypes: ModelTypeOption[] = [
+    {
+      id: ModelTypeId.TFJS,
+      label: 'TFJS model',
+    },
+    // TODO: the following types are disabled for now. Will enable them as they
+    // are implemented.
+    {
+      id: ModelTypeId.TF,
+      label: 'TF model',
+      disabled: true,
+    },
+    {
+      id: ModelTypeId.TFLITE,
+      label: 'TFLite model',
+      disabled: true,
+    },
+    {
+      id: ModelTypeId.TFJS_CUSTOM_GRAPH,
+      label: 'Custom TFJS model graph',
+      disabled: true,
+    },
+  ];
+
+  /** Stores the currently selected model type. */
+  selectedModelTypeId!: ModelTypeId;
+
+  private active = true;
+
+  constructor(
+      private readonly changeDetectorRef: ChangeDetectorRef,
+      private readonly store: Store<AppState>,
+      private readonly urlService: UrlService,
+  ) {}
+
+  ngOnInit() {
+    // Add "Same as configuration 1" option when the model selector is used in
+    // the configuration 2.
+    if (this.configIndex === 1) {
+      this.modelTypes.unshift({
+        id: ModelTypeId.SAME_AS_CONFIG1,
+        label: 'Same as configuration 1',
+      });
+    }
+
+    // Update currently selected model type from URL.
+    this.store
+        .select(selectConfigValueFromUrl(
+            this.configIndex, UrlParamKey.SELECTED_MODEL_TYPE_ID))
+        .pipe(takeWhile(() => this.active))
+        .subscribe((strId) => {
+          // First one is the default.
+          let modelTypeId = this.modelTypes[0].id;
+          if (strId != null) {
+            modelTypeId = Number(strId);
+          }
+          this.selectedModelTypeId = modelTypeId;
+          this.changeDetectorRef.markForCheck();
+        });
+  }
+
+  ngOnDestroy() {
+    this.active = false;
+  }
+
+  handleSelectionChange(event: MatSelectChange) {
+    const modelTypeId = event.value as ModelTypeId;
+
+    // Do things after a new model type is selected.
+    //
+    // Note that this method will only be triggered through user actions (e.g.
+    // click the drop down and select an item), not other non-user actions such
+    // as restoring states from URL or going forward/backward in browser
+    // history.
+    switch (modelTypeId) {
+      // Immediately focus on the the model url input whenn TFJS model is
+      // selected.
+      case ModelTypeId.TFJS:
+        setTimeout(() => {
+          this.tfjsModelUrlInput.nativeElement.focus();
+        });
+        break;
+
+      default:
+        break;
+    }
+    // TODO: record model url to url.
+    sddsd;
+
+    // Update url with selected model type id.
+    this.urlService.updateUrlParameter(
+        appendConfigIndexToKey(
+            UrlParamKey.SELECTED_MODEL_TYPE_ID, this.configIndex),
+        `${modelTypeId}`);
+  }
+
+  get isSameAsConfig1Selected(): boolean {
+    return this.selectedModelTypeId === ModelTypeId.SAME_AS_CONFIG1;
+  }
+}

--- a/toolings/tfjs-debugger/src/app/components/model_selector/model_selector.module.ts
+++ b/toolings/tfjs-debugger/src/app/components/model_selector/model_selector.module.ts
@@ -1,0 +1,24 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatSelectModule} from '@angular/material/select';
+
+import {ModelSelector} from './model_selector.component';
+
+@NgModule({
+  declarations: [
+    ModelSelector,
+  ],
+  imports: [
+    CommonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+  ],
+  exports: [
+    ModelSelector,
+  ],
+})
+export class ModelSelectorModule {
+}

--- a/toolings/tfjs-debugger/src/app/components/model_selector/model_selector.module.ts
+++ b/toolings/tfjs-debugger/src/app/components/model_selector/model_selector.module.ts
@@ -1,5 +1,23 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
+import {FormsModule} from '@angular/forms';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
 import {MatSelectModule} from '@angular/material/select';
@@ -12,6 +30,7 @@ import {ModelSelector} from './model_selector.component';
   ],
   imports: [
     CommonModule,
+    FormsModule,
     MatFormFieldModule,
     MatInputModule,
     MatSelectModule,

--- a/toolings/tfjs-debugger/src/app/components/model_selector/types.ts
+++ b/toolings/tfjs-debugger/src/app/components/model_selector/types.ts
@@ -15,27 +15,12 @@
  * =============================================================================
  */
 
-import {Configuration} from '../data_model/configuration';
-import {ModelTypeId} from '../data_model/model_type';
+import {ModelTypeId} from 'src/app/data_model/model_type';
 
-export interface Configs {
-  config1: Configuration;
-  config2: Configuration;
+/** An option in the model selector. */
+export interface ModelTypeOption {
+  /** This is a number not string. */
+  id: ModelTypeId;
+  label: string;
+  disabled?: boolean;
 }
-
-/** The main app state. */
-export interface AppState {
-  configs: Configs;
-}
-
-/** The initial app state. */
-export const initialState: AppState = {
-  configs: {
-    config1: {
-      modelType: ModelTypeId.TFJS,
-    },
-    config2: {
-      modelType: ModelTypeId.SAME_AS_CONFIG1,
-    }
-  },
-};

--- a/toolings/tfjs-debugger/src/app/data_model/configuration.ts
+++ b/toolings/tfjs-debugger/src/app/data_model/configuration.ts
@@ -15,6 +15,8 @@
  * =============================================================================
  */
 
+import {ModelTypeId} from './model_type';
+
 export interface Configuration {
-  // TODO: placeholder.
+  modelType: ModelTypeId;
 }

--- a/toolings/tfjs-debugger/src/app/data_model/model_type.ts
+++ b/toolings/tfjs-debugger/src/app/data_model/model_type.ts
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 /** Model type ids. */
 export enum ModelTypeId {
   TFJS,

--- a/toolings/tfjs-debugger/src/app/data_model/model_type.ts
+++ b/toolings/tfjs-debugger/src/app/data_model/model_type.ts
@@ -1,0 +1,8 @@
+/** Model type ids. */
+export enum ModelTypeId {
+  TFJS,
+  TF,
+  TFLITE,
+  TFJS_CUSTOM_GRAPH,
+  SAME_AS_CONFIG1,
+}

--- a/toolings/tfjs-debugger/src/app/services/url_service.ts
+++ b/toolings/tfjs-debugger/src/app/services/url_service.ts
@@ -1,5 +1,22 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 import {Injectable} from '@angular/core';
-import {Router} from '@angular/router';
+import {Params, Router} from '@angular/router';
 
 /**
  * Service for url related tasks.
@@ -12,10 +29,10 @@ export class UrlService {
       private readonly router: Router,
   ) {}
 
-  updateUrlParameter(paramKey: string, value: string) {
+  updateUrlParameters(params: Params) {
     this.router.navigate([], {
       queryParams: {
-        [paramKey]: value,
+        ...params,
       },
       queryParamsHandling: 'merge',
     });

--- a/toolings/tfjs-debugger/src/app/services/url_service.ts
+++ b/toolings/tfjs-debugger/src/app/services/url_service.ts
@@ -1,0 +1,23 @@
+import {Injectable} from '@angular/core';
+import {Router} from '@angular/router';
+
+/**
+ * Service for url related tasks.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class UrlService {
+  constructor(
+      private readonly router: Router,
+  ) {}
+
+  updateUrlParameter(paramKey: string, value: string) {
+    this.router.navigate([], {
+      queryParams: {
+        [paramKey]: value,
+      },
+      queryParamsHandling: 'merge',
+    });
+  }
+}

--- a/toolings/tfjs-debugger/src/app/store/actions.ts
+++ b/toolings/tfjs-debugger/src/app/store/actions.ts
@@ -15,4 +15,12 @@
  * =============================================================================
  */
 
-// TODO: placeholder.
+import {createAction, props} from '@ngrx/store';
+
+import {ModelTypeId} from '../data_model/model_type';
+
+/** Sets model type for the given config. */
+export const setModelType = createAction(
+    '[Conf] Set Model Type',
+    props<{configIndex: number, modelType: ModelTypeId}>(),
+);

--- a/toolings/tfjs-debugger/src/app/store/selectors.ts
+++ b/toolings/tfjs-debugger/src/app/store/selectors.ts
@@ -16,9 +16,21 @@
  */
 
 import {getSelectors, RouterReducerState} from '@ngrx/router-store';
-import {createFeatureSelector} from '@ngrx/store';
+import {createFeatureSelector, createSelector} from '@ngrx/store';
+
+import {ConfigIndex, UrlParamKey} from '../common/types';
+import {appendConfigIndexToKey} from '../common/utils';
 
 const selectRouter = createFeatureSelector<RouterReducerState>('router');
 const selectQueryParams = getSelectors(selectRouter).selectQueryParams;
 
-// TODO: placeholder.
+/** Selector to select the id of the currently selected model item from URL. */
+export const selectConfigValueFromUrl =
+    (configIndex: ConfigIndex, paramKey: UrlParamKey) =>
+        createSelector(selectQueryParams, (params) => {
+          if (!params) {
+            return '';
+          }
+          const key = appendConfigIndexToKey(paramKey, configIndex);
+          return params[key];
+        });

--- a/toolings/tfjs-debugger/src/app/store/selectors.ts
+++ b/toolings/tfjs-debugger/src/app/store/selectors.ts
@@ -29,7 +29,7 @@ export const selectConfigValueFromUrl =
     (configIndex: ConfigIndex, paramKey: UrlParamKey) =>
         createSelector(selectQueryParams, (params) => {
           if (!params) {
-            return '';
+            return undefined;
           }
           const key = appendConfigIndexToKey(paramKey, configIndex);
           return params[key];

--- a/toolings/tfjs-debugger/src/styles.scss
+++ b/toolings/tfjs-debugger/src/styles.scss
@@ -16,6 +16,7 @@
  */
 
 @use 'variables' as var;
+@use 'theme' as theme;
 
 body {
   height: 100%;
@@ -25,4 +26,37 @@ body {
 
 html {
   height: 100%;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Styles that are applied to all elements in the app.
+
+// Common styles for certain controls.
+mat-form-field.mat-form-field-type-mat-select,
+mat-form-field.mat-form-field-type-mat-input {
+  .mat-form-field-infix {
+    padding-top: 11px;
+    padding-bottom: 7px;
+    border-top-width: 0;
+  }
+
+  .mat-form-field-wrapper {
+    padding: 0;
+  }
+}
+
+// mat-select
+mat-form-field.mat-form-field-type-mat-select {
+  .mat-select-arrow-wrapper {
+    transform: none;
+  }
+}
+
+// mat-option
+mat-option.mat-selected {
+  background: theme.$primary-color !important;
+
+  .mat-option-text {
+    color: var.$grey-900;
+  }
 }

--- a/toolings/tfjs-debugger/src/variables.scss
+++ b/toolings/tfjs-debugger/src/variables.scss
@@ -15,4 +15,31 @@
  * =============================================================================
  */
 
+// Text styles.
 $font-face: 'Google Sans', sans-serif;
+$font-size-small: 13px;
+$font-size-normal: 14px;
+$font-size-large: 16px;
+
+// Colors.
+$grey-50: #fafafa;
+$grey-100: #f5f5f5;
+$grey-200: #eee;
+$grey-300: #e0e0e0;
+$grey-400: #bdbdbd;
+$grey-500: #9e9e9e;
+$grey-600: #757575;
+$grey-700: #616161;
+$grey-800: #424242;
+$grey-900: #212121;
+
+// Spacings.
+$spacing-1x: 4px;
+$spacing-2x: 8px;
+$spacing-3x: 12px;
+$spacing-4x: 16px;
+$spacing-5x: 20px;
+$spacing-6x: 24px;
+
+// Sizes.
+$config-header-height: 28px;

--- a/toolings/tfjs-debugger/src/variables.scss
+++ b/toolings/tfjs-debugger/src/variables.scss
@@ -17,6 +17,7 @@
 
 // Text styles.
 $font-face: 'Google Sans', sans-serif;
+$font-size-smaller: 12px;
 $font-size-small: 13px;
 $font-size-normal: 14px;
 $font-size-large: 16px;

--- a/toolings/tfjs-debugger/yarn.lock
+++ b/toolings/tfjs-debugger/yarn.lock
@@ -1789,25 +1789,10 @@ ansi-html-community@^0.0.8:
   resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
   integrity sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==
 
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
-
-ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
-
-ansi-regex@^5.0.1:
+ansi-regex@^2.0.0, ansi-regex@^4.1.0, ansi-regex@^5.0.1, ansi-regex@^6.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
-
-ansi-regex@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
-  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
@@ -2306,7 +2291,7 @@ camelcase@^4.1.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
 
-camelcase@^5.3.1:
+camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
@@ -3809,27 +3794,12 @@ get-value@^2.0.3, get-value@^2.0.6:
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
-glob-parent@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
-  integrity sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=
-  dependencies:
-    is-glob "^3.1.0"
-    path-dirname "^1.0.0"
-
-glob-parent@^5.1.2, glob-parent@~5.1.2:
+glob-parent@^3.1.0, glob-parent@^5.1.2, glob-parent@^6.0.0, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
-
-glob-parent@^6.0.0:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
-  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
-  dependencies:
-    is-glob "^4.0.3"
 
 glob-to-regexp@^0.3.0:
   version "0.3.0"
@@ -4482,7 +4452,7 @@ is-extendable@^1.0.1:
   dependencies:
     is-plain-object "^2.0.4"
 
-is-extglob@^2.1.0, is-extglob@^2.1.1:
+is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
@@ -4504,14 +4474,7 @@ is-fullwidth-code-point@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
-is-glob@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
-  integrity sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=
-  dependencies:
-    is-extglob "^2.1.0"
-
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -4577,7 +4540,7 @@ is-plain-obj@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-3.0.0.tgz#af6f2ea14ac5a646183a5bbdb5baabbc156ad9d7"
   integrity sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==
 
-is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
@@ -4588,6 +4551,11 @@ is-plain-object@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
   integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
+
+is-primitive@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-3.0.1.tgz#98c4db1abff185485a657fc2905052b940524d05"
+  integrity sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w==
 
 is-regex@^1.0.4:
   version "1.1.4"
@@ -6009,11 +5977,6 @@ pascalcase@^0.1.1:
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
-path-dirname@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
-  integrity sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=
-
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
@@ -7225,15 +7188,13 @@ set-blocking@~2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
-set-value@^2.0.0, set-value@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
-  integrity sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
+set-value@^2.0.0, set-value@^2.0.1, set-value@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-4.1.0.tgz#aa433662d87081b75ad88a4743bd450f044e7d09"
+  integrity sha512-zTEg4HL0RwVrqcWs3ztF+x1vkxfm0lP+MQQFPiMJTKVceBwEV0A569Ou8l9IYQG8jOZdMVI1hGsc0tmeD2o/Lw==
   dependencies:
-    extend-shallow "^2.0.1"
-    is-extendable "^0.1.1"
-    is-plain-object "^2.0.3"
-    split-string "^3.0.1"
+    is-plain-object "^2.0.4"
+    is-primitive "^3.0.1"
 
 setprototypeof@1.1.0:
   version "1.1.0"
@@ -7504,7 +7465,7 @@ specificity@^0.4.1:
   resolved "https://registry.yarnpkg.com/specificity/-/specificity-0.4.1.tgz#aab5e645012db08ba182e151165738d00887b019"
   integrity sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==
 
-split-string@^3.0.1, split-string@^3.0.2:
+split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
   integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
@@ -8044,12 +8005,7 @@ tree-kill@1.2.2:
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
-trim-newlines@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20"
-  integrity sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=
-
-trim-newlines@^3.0.0:
+trim-newlines@^2.0.0, trim-newlines@^3.0.0, trim-newlines@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
@@ -8059,10 +8015,10 @@ trim-trailing-lines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz#bd4abbec7cc880462f10b2c8b5ce1d8d1ec7c2c0"
   integrity sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==
 
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
-  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
+trim@0.0.1, trim@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.3.tgz#05243a47a3a4113e6b49367880a9cca59697a20b"
+  integrity sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg==
 
 trough@^1.0.0:
   version "1.0.5"
@@ -8617,17 +8573,13 @@ yaml@^1.10.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yargs-parser@^10.0.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
-  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
+yargs-parser@^10.0.0, yargs-parser@^13.1.2, yargs-parser@^20.2.2, yargs-parser@^20.2.3:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
+  integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
   dependencies:
-    camelcase "^4.1.0"
-
-yargs-parser@^20.2.2, yargs-parser@^20.2.3:
-  version "20.2.9"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
-  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
 
 yargs@^16.1.1:
   version "16.2.0"


### PR DESCRIPTION
This PR adds the components for basic UI structure:
- AppBar (top)
- GraphPanel (center)
- InfoPanel (right)
- ConfigsPanel (left)
  - ConfigSection (each configuration is a ConfigSection)
     - ModelSelector -> A component for users to select model type. Only TFJS model is supported.

I implemented the basic functionalities of ModelSelector:
- Show a model url input when "TFJS model" is selected
- Encode/Decode states (e.g. selected model type, model url string) to/from URL
- Add tests.

You can check out the preview [here](https://tfjs-debugger--20211112-191853-mdc22o4z.web.app/). Deep linking (only for model selector) should also work. For example, this [link](https://tfjs-debugger--20211112-191853-mdc22o4z.web.app/?tfjsmu__0=www.mymodel.com%2Fmodel.json&mid__1=4) should set the model url to www.mymodel.com/model.json.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/sig-tfjs/4)
<!-- Reviewable:end -->
