### PR TITLE
Pass WebNN options as a strongly typed object

### DIFF
--- a/webnn-tflite-delegate/src/index.ts
+++ b/webnn-tflite-delegate/src/index.ts
@@ -24,18 +24,33 @@ const libNames = new Map<NodeJS.Platform, string>([
   ['win32', path.join(__dirname, '../cc_lib/win32_x64/webnn_external_delegate_obj.dll')],
 ]);
 
+export enum WebNNDevice {
+  DEFAULT = '0',
+  GPU = '1',
+  CPU = '2',
+}
+
+export interface WebNNOptions {
+  webnnDevice?: WebNNDevice;
+}
+
 export class WebNNDelegate implements TFLiteDelegatePlugin {
   readonly name = 'WebNNDelegate';
   readonly tfliteVersion = '2.7';
   readonly node: TFLiteDelegatePlugin['node'];
+  readonly options: Array<[string, string]> = [];
 
-  constructor(readonly options: Array<[string, string]> = [],
+  constructor(options: WebNNOptions = {},
               libPath?: string, platform = os.platform()) {
     if (!libPath) {
       libPath = libNames.get(platform);
       if (!libPath) {
         throw new Error(`Unknown platform ${platform}`);
       }
+    }
+
+    if (options.webnnDevice !== undefined) {
+      this.options.push(['webnn_device', options.webnnDevice]);
     }
 
     this.node = {

--- a/webnn-tflite-delegate/src/index_test.ts
+++ b/webnn-tflite-delegate/src/index_test.ts
@@ -16,7 +16,7 @@
  */
 
 import '@tensorflow/tfjs-backend-cpu';
-import {WebNNDelegate} from './index';
+import {WebNNDelegate, WebNNDevice} from './index';
 import * as path from 'path';
 
 describe('webnn delegate', () => {
@@ -29,20 +29,21 @@ describe('webnn delegate', () => {
   });
 
   it('stores options', () => {
-    const options: Array<[string, string]> = [['foo', 'bar'], ['123', '456']];
-    const webnnDelegate = new WebNNDelegate(options);
-    expect(webnnDelegate.options).toEqual(options);
+    const webnnDelegate = new WebNNDelegate({
+      webnnDevice: WebNNDevice.GPU,
+    });
+    expect(webnnDelegate.options).toEqual([['webnn_device', WebNNDevice.GPU]]);
   });
 
   it('allows manually setting lib path', () => {
     const libPath = 'some lib path';
-    const webnnDelegate = new WebNNDelegate([], libPath);
+    const webnnDelegate = new WebNNDelegate({}, libPath);
     expect(webnnDelegate.node.path).toEqual(libPath);
   });
 
   it('sets the lib path automatically based on platorm', () => {
-    const webnnLinux = new WebNNDelegate([], undefined, 'linux');
-    const webnnWindows = new WebNNDelegate([], undefined, 'win32');
+    const webnnLinux = new WebNNDelegate({}, undefined, 'linux');
+    const webnnWindows = new WebNNDelegate({}, undefined, 'win32');
 
     const pathPrefix = path.join(__dirname, '../cc_lib');
     expect(webnnLinux.node.path).toEqual(

--- a/webnn-tflite-delegate/src/integration_test/index_test.ts
+++ b/webnn-tflite-delegate/src/integration_test/index_test.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {WebNNDelegate} from '../index';
+import {WebNNDelegate, WebNNDevice} from '../index';
 import {loadTFLiteModel} from 'tfjs-tflite-node';
 import type {TFLiteModel} from 'tfjs-tflite-node/dist/tflite_model';
 import * as fs from 'fs';
@@ -31,8 +31,7 @@ describe('webnn delegate', () => {
 
   beforeEach(async () => {
     model = await loadTFLiteModel(modelPath, {
-      // 'webnn_device' option: (0:default, 1:gpu, 2:cpu)
-      delegates: [new WebNNDelegate([['webnn_device', '2']])],
+      delegates: [new WebNNDelegate({webnnDevice: WebNNDevice.CPU})],
     });
 
     // Load the input image of a wine.


### PR DESCRIPTION
Instead of passing options to the WebNN delegate as `Array<[string, string]>`, use a strongly typed object that prevents incorrect or extraneous options from being passed and works with TypeScript code completion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/sig-tfjs/26)
<!-- Reviewable:end -->
